### PR TITLE
Attempt fixing logstf upload problem

### DIFF
--- a/includes/anyhttp.inc
+++ b/includes/anyhttp.inc
@@ -149,15 +149,29 @@ methodmap AnyHttpRequest {
         KvizSetString(kv, "file", "%i.type",  id);
         KvizSetString(kv, "true", "%i.cleanup",  id);
 
-        char filename[128];
-        GenerateUniqueFilename(filename, sizeof(filename));
-        if (!CopyFile(filepath, filename)) {
-            LogError("Could not copy file from %s to %s", filepath, filename);
-            strcopy(filename, sizeof(filename), filepath);
+        // To avoid locking the file, we copy it to a temporary location.
+        // Put the temp file in the same directory as the file to be uploaded
+        char tempFilepath[128];
+        strcopy(tempFilepath, sizeof(tempFilepath), filepath);
+        int posOfDirSeparator = FindCharInString(tempFilepath, '/', true);
+        if (posOfDirSeparator == -1)
+            posOfDirSeparator = FindCharInString(tempFilepath, '\\', true);
+        if (posOfDirSeparator == -1) {
+            tempFilepath = "";
+        } else {
+            tempFilepath[posOfDirSeparator + 1] = '\0';
+        }
+        char tempFilename[128];
+        GenerateUniqueFilename(tempFilename, sizeof(tempFilename));
+        StrCat(tempFilepath, sizeof(tempFilepath), tempFilename);
+
+        if (!CopyFile(filepath, tempFilepath)) {
+            LogError("Could not copy file from %s to %s", filepath, tempFilepath);
+            strcopy(tempFilepath, sizeof(tempFilepath), filepath);
             KvizSetString(kv, "false", "%i.cleanup",  id);
         }
     
-        KvizSetString(kv, filename, "%i.value", id);
+        KvizSetString(kv, tempFilepath, "%i.value", id);
     }
     
     public void PutString(const char[] name, const char[] value) {

--- a/includes/anyhttp.inc
+++ b/includes/anyhttp.inc
@@ -48,7 +48,7 @@ TODO:
 #define ANYHTTP_VERSION		     "2.0.0"
 #define SimultaneousConnections  16
 
-#pragma dynamic 20971520 // Make sure we can allocate enough space for uploading files. Here's 20MB.
+#pragma dynamic 5242880 // Make sure we can allocate enough space for uploading files. Here's 20MB.
 
 enum AnyHttp_Extension {
     AnyHttpUnknown,
@@ -143,11 +143,21 @@ methodmap AnyHttpRequest {
 
     public void PutFile(const char[] name, const char[] filepath) {
         Handle kv = this.Fields;
-    
+
         int id = KvizGetNum(kv, 0, ":count") + 1;
         KvizSetString(kv, name, "%i.name", id);
         KvizSetString(kv, "file", "%i.type",  id);
-        KvizSetString(kv, filepath, "%i.value", id);
+        KvizSetString(kv, "true", "%i.cleanup",  id);
+
+        char filename[128];
+        GenerateUniqueFilename(filename, sizeof(filename));
+        if (!CopyFile(filepath, filename)) {
+            LogError("Could not copy file from %s to %s", filepath, filename);
+            strcopy(filename, sizeof(filename), filepath);
+            KvizSetString(kv, "false", "%i.cleanup",  id);
+        }
+    
+        KvizSetString(kv, filename, "%i.value", id);
     }
     
     public void PutString(const char[] name, const char[] value) {
@@ -261,6 +271,9 @@ static AnyHttpRequest NewRequest() {
 }
 
 static void CleanUpRequest(AnyHttpRequest request) {
+    if (!request.Initialized)
+        return;
+    
     request.Initialized = false;
     if (request.ExtensionHandle != null) {
         CloseHandle(request.ExtensionHandle);
@@ -270,7 +283,24 @@ static void CleanUpRequest(AnyHttpRequest request) {
         CloseHandle(request.FileHandle);
         request.FileHandle = null;
     }
-    KvizClose(request.Fields);
+    if (request.Fields != null) {
+        char type[64];
+        for (int i = 1; KvizGetStringExact(request.Fields, type, sizeof(type), "%i.type", i); i++) {
+            if (StrEqual(type, "file")) {
+                char cleanup[16];
+                KvizGetStringExact(request.Fields, cleanup, sizeof(cleanup), "%i.cleanup", i);
+                if (StrEqual(cleanup, "true")) {
+                    char filepath[1024];
+                    KvizGetStringExact(request.Fields, filepath, sizeof(filepath), "%i.value", i);
+                    if (!DeleteFile(filepath, false))
+                        LogError("Could not delete %s", filepath);
+                }
+            }
+        }
+
+        KvizClose(request.Fields);
+        request.Fields = null;
+    }
 }
 
 static bool FindRequestByHandle(Handle handle, AnyHttpRequest &request) {
@@ -326,12 +356,18 @@ static bool AppendMultipartFile(char[] buffer, int &bufferPos, int maxsize, cons
         bufferPos += filesize;
     } else {
         File filehandle = OpenFile(filepath, "rb");
-        if (filehandle == null)
+        if (filehandle == null) {
+            LogError("AppendMultipartFile: Could not open file for reading %s", filepath);
             return false;
+        }
+        
         for (int i = 0; i < filesize; i++) {
             int byte;
-            if (!filehandle.ReadUint8(byte))
+            if (!filehandle.ReadUint8(byte)) {
+                LogError("AppendMultipartFile: Could not read byte from %s", filepath);
+                filehandle.Close();
                 return false;
+            }
             buffer[bufferPos++] = view_as<char>(byte);
         }
         filehandle.Close();
@@ -360,6 +396,33 @@ static int CopyBytes(char[] dest, int destSize, const char[] src, int destPos, i
     if (bytesCopied < bytes)
         ThrowError("AnyHttp: Not enough space allocated");
     return bytesCopied;
+}
+
+static bool CopyFile(const char[] sourceFile, const char[] targetFile)
+{
+	File hr = OpenFile(sourceFile, "rb", false);	
+    if (hr == null)
+        return false;
+
+    File hw = OpenFile(targetFile, "wb", false);	
+    if (hw == null) {
+        hr.Close();
+        return false;
+    }
+    
+    int bytesRead, buff[1024];
+    bool success = true;
+    while (!hr.EndOfFile()) {
+        bytesRead = hr.Read(buff, sizeof(buff), 1);
+        if (bytesRead == -1 || !hw.Write(buff, bytesRead, 1)) {
+            success = false;
+            break;
+        }
+    }
+
+    hw.Close();
+    hr.Close();
+    return success;
 }
 
 static void GenerateUniqueFilename(char[] filename, int maxsize) {

--- a/logstf/README.md
+++ b/logstf/README.md
@@ -1,0 +1,19 @@
+# LogsTF
+
+Features:
+
+- **Note:** Requires the [SteamWorks](http://users.alliedmods.net/~kyles/builds/SteamWorks/) ([mirror](https://github.com/hexa-core-eu/SteamWorks/releases)) extension, or the cURL extension.
+- Automatically uploads logs to [logs.tf](https://logs.tf)
+- You can see the logs in-game by typing `!logs` or `.ss`
+- Uploads logs after each round (the log will be updated on logs.tf after each round), so you can use `!logs`/`.ss` after each round
+- Fixes several bugs seen in other plugins (including the last round missing, and stats being wrong when you play two matches on the same map)
+
+Available CVARs:
+| CVAR | Default | Description |
+| --- | --- | --- |
+| `logstf_apikey <key>` | (empty) | Sets your Logs.TF API key. Required for the plugin to work. |
+| `logstf_title <title>` | `{server}: {red} vs {blu}` | Sets the title of the log.<br>Use `{server}` to insert the server title.<br>Use `{red}` or `{blu}` to insert team names. |
+| `logstf_autoupload <0\|1\|2>` | `2` | Set to 2 to upload logs from all matches.<br>Set to 1 to upload logs from matches with at least 4 players.<br>Set to 0 to disable automatic upload. |
+| `logstf_midgameupload <0\|1>` | `1` | Set to 0 to upload logs after the match has finished.<br>Set to 1 to upload the logs after each round. |
+| `logstf_midgamenotice <0\|1>` | `1` | Set to 1 to notice players about midgame logs. |
+| `logstf_suppresschat <0\|1>` | `1` | Set to 1 to hide '!log' chats. |

--- a/logstf/logstf.sp
+++ b/logstf/logstf.sp
@@ -86,7 +86,7 @@ Release notes:
 - More internal syntax updates
 
 
----- 2.5.0 ----
+---- 2.5.0 (02/10/2022) ----
 - Reduced risk of file locks messing up log upload
 - Added cvar 'logstf_suppresschat'
 
@@ -113,7 +113,7 @@ TODO:
 #include <updater>
 
 
-#define PLUGIN_VERSION	"2.5.0"
+#define PLUGIN_VERSION	"2.4.9"
 #define UPDATE_URL		"http://sourcemod.krus.dk/logstf/update.txt"
 
 #define LOG_PATH  "logstf.log"

--- a/logstf/logstf.sp
+++ b/logstf/logstf.sp
@@ -88,6 +88,7 @@ Release notes:
 
 ---- 2.5.0 ----
 - Reduced risk of file locks messing up log upload
+- Added cvar 'logstf_suppresschat'
 
 
 
@@ -203,7 +204,7 @@ public void OnPluginStart() {
 	g_hCvarAutoUpload = CreateConVar("logstf_autoupload", "2", "Set to 2 to upload logs from all matches. (default)\n - Set to 1 to upload logs from matches with at least 4 players.\n - Set to 0 to disable automatic upload. Admins can still upload logs by typing !ul", FCVAR_NONE);
 	g_hCvarMidGameUpload = CreateConVar("logstf_midgameupload", "1", "Set to 0 to upload logs after the match has finished.\n - Set to 1 to upload the logs after each round.", FCVAR_NONE);
 	g_hCvarMidGameNotice = CreateConVar("logstf_midgamenotice", "1", "Set to 1 to notice players about midgame logs.\n - Set to 0 to disable it.", FCVAR_NONE);
-	g_hCvarSuppressChat = CreateConVar("logstf_suppresschat", "0", "Set to 1 to hide '!log' chats.", FCVAR_NONE);
+	g_hCvarSuppressChat = CreateConVar("logstf_suppresschat", "0", "Set to 1 to hide '!log' chats.\n - Set to 0 to show '!log' chats.", FCVAR_NONE);
 
 	// Events
 	HookEvent("teamplay_round_win", Event_RoundEnd);

--- a/logstf/logstf.sp
+++ b/logstf/logstf.sp
@@ -113,7 +113,7 @@ TODO:
 #include <updater>
 
 
-#define PLUGIN_VERSION	"2.4.1"
+#define PLUGIN_VERSION	"2.5.0"
 #define UPDATE_URL		"http://sourcemod.krus.dk/logstf/update.txt"
 
 #define LOG_PATH  "logstf.log"

--- a/logstf/logstf.sp
+++ b/logstf/logstf.sp
@@ -113,7 +113,7 @@ TODO:
 #include <updater>
 
 
-#define PLUGIN_VERSION	"2.4.9"
+#define PLUGIN_VERSION	"2.5.0"
 #define UPDATE_URL		"http://sourcemod.krus.dk/logstf/update.txt"
 
 #define LOG_PATH  "logstf.log"

--- a/logstf/update.txt
+++ b/logstf/update.txt
@@ -4,11 +4,12 @@
 	{
 		"Version"
 		{
-			"Latest"	"2.4.1"
+			"Latest"	"2.5.0"
 		}
 		
-		"Notes"	"Changes in 2.4.1:"
-		"Notes"	"- More internal syntax updates"
+		"Notes"	"Changes in 2.5.0:"
+		"Notes"	"- Reduced risk of file locks messing up log upload"
+		"Notes"	"- Added cvar 'logstf_suppresschat'"
 	}
 	
 	"Files"


### PR DESCRIPTION
Fixes #10 and hopefully fixes #9.

Now the file-to-be-uploaded is copied to a temp location, uploaded and then deleted. This makes sure that the process of uploading it doesn't block new log lines to be written.
