### PR TITLE
Added logging of airshots with crossbows

### DIFF
--- a/supstats2/supstats2.sp
+++ b/supstats2/supstats2.sp
@@ -70,7 +70,7 @@ Release notes:
 
 
 ---- 2.5.0 (15/10/2022) ----
-- Added logs for crossbow airshots
+- Added logs for crossbow airshots - by TheBv
 
 
 

--- a/supstats2/supstats2.sp
+++ b/supstats2/supstats2.sp
@@ -70,7 +70,7 @@ Release notes:
 
 
 ---- 2.5.0 (15/10/2022) ----
-- Added logs for crossbow airshots - by TheBv
+- Added logs for crossbow airshots - by Bv
 
 
 

--- a/supstats2/update.txt
+++ b/supstats2/update.txt
@@ -8,7 +8,7 @@
 		}
 		
 		"Notes"	"Changes in 2.5.0:"
-		"Notes"	"- Added logs for crossbow airshots"
+		"Notes"	"- Added logs for crossbow airshots - by Bv"
 	}
 	
 	"Files"

--- a/supstats2/update.txt
+++ b/supstats2/update.txt
@@ -4,13 +4,11 @@
 	{
 		"Version"
 		{
-			"Latest"	"2.4.0"
+			"Latest"	"2.5.0"
 		}
 		
-		"Notes"	"Changes in 2.4.0:"
-		"Notes"	"- Added pause length to logs"
-		"Notes"	"- Fixed 'pause' logs being wrong"
-		"Notes"	"- Fixed SM error logs when picking up medpacks"
+		"Notes"	"Changes in 2.5.0:"
+		"Notes"	"- Added logs for crossbow airshots"
 	}
 	
 	"Files"


### PR DESCRIPTION
Adds the property `(airshot "1")` to the `healed against` event as well as the `damage` event.

Airshots on teammates won't show up on logs.tf.