### PR TITLE
Added height prop to airshots and switched to using hull raycasting

### DIFF
--- a/supstats2/update.txt
+++ b/supstats2/update.txt
@@ -4,11 +4,12 @@
 	{
 		"Version"
 		{
-			"Latest"	"2.5.0"
+			"Latest"	"2.5.1"
 		}
 		
-		"Notes"	"Changes in 2.5.0:"
-		"Notes"	"- Added logs for crossbow airshots - by Bv"
+		"Notes"	"Changes in 2.5.1:"
+		"Notes"	"- Added height prop to airshot logs - by Bv"
+		"Notes"	"- Switched to using HullRayTracing to eliminate edge-cases - by Bv"
 	}
 	
 	"Files"


### PR DESCRIPTION
Adds a height prop to airshots logging the calculated distance from the target to the ground.
This may help in differentiating between "good" and "bad" airshots in post processing.

This PR also switches the default RayCast to a Hull based raycast.
This eliminates some edge cases (literally) where a player may just be jumping near an edge and it counting as an airshot.
Originally I made this to fix issues with players standing on non-flat ground counting as airshots but this has since been fixed.

I'm not sure if the second "fix" is desirable or not. One could also tweak the size of the box to allow for more leeway.