### PR TITLE
supstats2: Prevent execution timeout on startup

### DIFF
--- a/supstats2/supstats2.sp
+++ b/supstats2/supstats2.sp
@@ -1553,7 +1553,7 @@ public Action ImportWeaponDefinitionsChunk(Handle timer, int startId) {
 
 	if (itemId > lastId) {
 		CreateTimer(0.1, ImportWeaponDefinitionsChunk, itemId);
-		return Plugin_Continue;
+		return Plugin_Stop;
 	}
 
 	// Clean up
@@ -1570,7 +1570,7 @@ public Action ImportWeaponDefinitionsChunk(Handle timer, int startId) {
 
 	FinalizePluginInitialization();
 
-	return Plugin_Continue;
+	return Plugin_Stop;
 }
 
 void GetItemString(KeyValues kv, KeyValues kvPrefabs, const char[] key, char[] value, int valueLen, const char[] def = "") {

--- a/supstats2/update.txt
+++ b/supstats2/update.txt
@@ -4,12 +4,11 @@
 	{
 		"Version"
 		{
-			"Latest"	"2.5.2"
+			"Latest"	"2.5.3"
 		}
 		
-		"Notes"	"Changes in 2.5.2:"
-		"Notes"	"- Removed 'spawned as unknown' log"
-		"Notes"	"- Internal updates - by Leigh MacDonald"
+		"Notes"	"Changes in 2.5.3:"
+		"Notes"	"- Prevent script execution timeout on startup"
 	}
 	
 	"Files"


### PR DESCRIPTION
On some slower machines, importing the weapon data takes too long, so the plugin gets shut down due to "execution timeout". I am also seeing that importing weapon data is much slower when running the 64-bit version (srcds_win64.exe).

This imports the data in chunks, which fixes the problem.

Fixes #35