### PR TITLE
Fixed wrong score count on some logs

### DIFF
--- a/logstf/logstf.inc
+++ b/logstf/logstf.inc
@@ -1,0 +1,2 @@
+forward void LogUploaded(bool success, const char[] logid, const char[] url);
+forward Action BlockLogLine(const char[] logline);

--- a/logstf/update.txt
+++ b/logstf/update.txt
@@ -4,11 +4,11 @@
 	{
 		"Version"
 		{
-			"Latest"	"2.6.3"
+			"Latest"	"2.6.4"
 		}
 		
-		"Notes"	"Changes in 2.6.3:"
-		"Notes"	"- Changed default value for logstf_title to match team order on logs.tf - by agrastiOs"
+		"Notes"	"Changes in 2.6.4:"
+		"Notes"	"- Fixed some logs having the wrong score count on logs.tf"
 	}
 	
 	"Files"


### PR DESCRIPTION
Should fix the wrong score count on some logs, e.g. [this](https://logs.tf/3750230).