### PR TITLE
supstats2: Add meta data logs (match id, map name, title)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Download all plugins in a zip file here: <a href="https://sourcemod.krus.dk/f2-s
 - Logs players spawning
 - Logs game pauses
 - Logs shots fired and shots hit (for certain weapons)
+- Logs unique match id, map name and title at the start of the match
 
 ### LogsTF <a href="https://sourcemod.krus.dk/logstf.zip"><img src="https://img.shields.io/badge/-download-informational" /></a> <a href="./logstf"><img src="https://img.shields.io/badge/-More%20info-yellowgreen" /></a>
 

--- a/includes/match.inc
+++ b/includes/match.inc
@@ -7,13 +7,13 @@ Remember to call:
 
 Then use these functions:
 
-StartMatch() {
+void StartMatch() {
 }
 
-ResetMatch() {
+void ResetMatch() {
 }
 
-EndMatch(bool:endedMidgame) {
+void EndMatch(bool endedMidgame) {
 }
 */
 

--- a/includes/match.inc
+++ b/includes/match.inc
@@ -15,12 +15,16 @@ void ResetMatch() {
 
 void EndMatch(bool endedMidgame) {
 }
+
+Optional:
+
+public void StartFirstRound() {
+}
+
 */
 
 /*
 TODO:
-- Dont call StartMatch before the 5-4-3-2-1 countdown reaches 0.
-- Make a new callback, AllPlayersReady
 - Make a new callback, AboutToEnd (5 secs before MatchEnded)
 - g_fMatchEndTime
 - g_bCountdownStarted
@@ -156,6 +160,12 @@ public void Match_Event_round_start(Event event, const char[] name, bool dontBro
 		
 		if (!g_bFirstRoundStarted) {
 			g_bFirstRoundStarted = true;
+
+			Function func = GetFunctionByName(null, "StartFirstRound");
+			if (func != null) {
+				Call_StartFunction(null, func);
+				Call_Finish();
+			}
 		}
 	}
 }

--- a/logs-spec.md
+++ b/logs-spec.md
@@ -221,3 +221,38 @@ When one team gets uber significantly before the other team, but does not use it
     "F2<3><[U:1:1234]><Red>" triggered "lost_uber_advantage" (time "14")
 
 Alternatively, this could also be computed by looking at the "chargeready" and "chargedeployed" logs from both teams.
+
+# Meta information
+
+Sometimes we want to write information to the logs that are not directly triggered by in-game events. We call this _meta information_.
+
+When it comes to these meta logs, **all properties are optional**.
+
+More properties can be added in the future, but the format of the ones listed should not be changed.
+
+## Player related
+
+To write meta info that is directly related to a player:
+
+    <player> triggered "meta_info" (position "%i %i %i")
+
+    "F2<3><[U:1:1234]><Red>" triggered "meta_info" (position "478 -334 603")
+
+It can have the following properties:
+
+- `position`: The current location of the player
+
+## Non-player related
+
+To write meta info that is not directly related to a player:
+
+    World triggered "meta_info" (matchid "%s") (map "%s") (title "%s")
+
+    World triggered "meta_info" (matchid "abc123") (map "cp_badlands") (title "serveme.tf #1337")
+
+It can have the following properties:
+
+- `matchid`: A randomly generated match id, hopefully unique (max 32 chars).  
+  This can be used to detect duplicate logs from the same match.
+- `map`: The current map
+- `title`: A title for the match (similar to the one sent to logs.tf)

--- a/logs-spec.md
+++ b/logs-spec.md
@@ -252,9 +252,13 @@ To write meta data that is not directly related to a player:
 
 It can have the following properties:
 
-- `matchid`: A randomly generated match id, hopefully unique (max 32 chars).  
+- `matchid`: A randomly generated match id, hopefully unique (max 32 alphanumeric chars).  
   This can be used to detect duplicate logs from the same match.
 - `map`: The current map
 - `title`: A title for the match (similar to the one sent to logs.tf)
 
-There can be multiple of these log lines in a match - for example, one logging the map and another one logging the title.
+There can be multiple of these log lines in a match, so for example you might see this:
+
+    World triggered "meta_data" (matchid "abc123")
+    World triggered "meta_data" (map "cp_badlands")
+    World triggered "meta_data" (title "serveme.tf #1337")

--- a/logs-spec.md
+++ b/logs-spec.md
@@ -232,6 +232,9 @@ More properties can be added in the future, but the format of the ones listed sh
 
 ## Player related
 
+> [!WARNING]
+> Player related logs have not been finalized, and parsers should not implement this yet.
+
 To write meta data that is directly related to a player:
 
     <player> triggered "meta_data" (position "%i %i %i")

--- a/logs-spec.md
+++ b/logs-spec.md
@@ -222,9 +222,9 @@ When one team gets uber significantly before the other team, but does not use it
 
 Alternatively, this could also be computed by looking at the "chargeready" and "chargedeployed" logs from both teams.
 
-# Meta information
+# Meta data
 
-Sometimes we want to write information to the logs that are not directly triggered by in-game events. We call this _meta information_.
+Sometimes we want to write information to the logs that are not directly triggered by in-game events. We call this _meta data_.
 
 When it comes to these meta logs, **all properties are optional**.
 
@@ -232,11 +232,11 @@ More properties can be added in the future, but the format of the ones listed sh
 
 ## Player related
 
-To write meta info that is directly related to a player:
+To write meta data that is directly related to a player:
 
-    <player> triggered "meta_info" (position "%i %i %i")
+    <player> triggered "meta_data" (position "%i %i %i")
 
-    "F2<3><[U:1:1234]><Red>" triggered "meta_info" (position "478 -334 603")
+    "F2<3><[U:1:1234]><Red>" triggered "meta_data" (position "478 -334 603")
 
 It can have the following properties:
 
@@ -244,11 +244,11 @@ It can have the following properties:
 
 ## Non-player related
 
-To write meta info that is not directly related to a player:
+To write meta data that is not directly related to a player:
 
-    World triggered "meta_info" (matchid "%s") (map "%s") (title "%s")
+    World triggered "meta_data" (matchid "%s") (map "%s") (title "%s")
 
-    World triggered "meta_info" (matchid "abc123") (map "cp_badlands") (title "serveme.tf #1337")
+    World triggered "meta_data" (matchid "abc123") (map "cp_badlands") (title "serveme.tf #1337")
 
 It can have the following properties:
 

--- a/logs-spec.md
+++ b/logs-spec.md
@@ -16,7 +16,7 @@ When we write `<player>`, `<attacker>` or similar, they refer to this format:
 
     "F2<3><[U:1:1234]><Red>"
 
-# Supplemental logs (supstats2)
+# Supplemental logs
 
 ## Pauses
 
@@ -158,7 +158,7 @@ For Crusader's Crossbow, friendly hits will be logged as `shot_hit`.
 
 Destroying a sticky with a hitscan weapon will be logged as `shot_hit` (although it might not always be accurately detected).
 
-# Medic Stats (medicstats)
+# Medic Stats
 
 **A note on vaccinator:** These logs are very bugged for vaccinator. For example, "charge ready" is only logged at 100%, but with vaccinator you can use charge at 25%. And it does not make sense talking about "uber advantage lost" when one team has uber and the other vaccinator. So, if one team uses vaccinator, think carefully about how you use these logs.
 

--- a/logs-spec.md
+++ b/logs-spec.md
@@ -256,3 +256,5 @@ It can have the following properties:
   This can be used to detect duplicate logs from the same match.
 - `map`: The current map
 - `title`: A title for the match (similar to the one sent to logs.tf)
+
+There can be multiple of these log lines in a match - for example, one logging the map and another one logging the title.

--- a/logstf/logstf.sp
+++ b/logstf/logstf.sp
@@ -125,6 +125,10 @@ Release notes:
 - Updated code to be compatible with SourceMod 1.12
 
 
+---- 2.6.7 (22/07/2025) ----
+- Changed match title trimming logic
+
+
 TODO:
 - Some people run multiple instances of the same server (located in the same directory). This is a problem, because they all write to the same logstf.log file. Make the logstf.log and -partial files have dynamic names, and don't forget to clean them up.
 - Sanitize names for < and >, since logs.tf doesn't like those
@@ -146,7 +150,7 @@ TODO:
 #undef REQUIRE_PLUGIN
 #include <updater>
 
-#define PLUGIN_VERSION	"2.6.6"
+#define PLUGIN_VERSION	"2.6.7"
 #define UPDATE_URL		"https://sourcemod.krus.dk/logstf/update.txt"
 
 #define LOG_PATH  "logstf.log"
@@ -364,6 +368,8 @@ void EndMatch(bool endedMidgame) {
 }
 
 void CacheMatchValues() {
+	// Note: If you are making changes related to title generation, also update supstats2.
+
 	g_hCvarHostname.GetString(g_sCachedHostname, sizeof(g_sCachedHostname));
 	g_hCvarBlueTeamName.GetString(g_sCachedBluTeamName, sizeof(g_sCachedBluTeamName));
 	g_hCvarRedTeamName.GetString(g_sCachedRedTeamName, sizeof(g_sCachedRedTeamName));
@@ -372,9 +378,10 @@ void CacheMatchValues() {
 	String_Trim(g_sCachedRedTeamName, g_sCachedRedTeamName, sizeof(g_sCachedRedTeamName));
 	GetCurrentMap(g_sCachedMap, sizeof(g_sCachedMap));
 
-	// Remove last word in hostname
+	// Trim the last words in hostname if it is a long hostname
 	int spacepos = -1;
-	for (int i = strlen(g_sCachedHostname) - 1; i >= 17; i--) {
+	int hostnameLen = strlen(g_sCachedHostname);
+	for (int i = 25; i < hostnameLen; i++) {
 		if (g_sCachedHostname[i] == ' ') {
 			spacepos = i;
 			break;
@@ -690,6 +697,7 @@ void UploadLog(bool partial) {
 	g_bIsUploading = true;
 	g_bIsPartialUpload = partial;
 
+	// Note: If you are making changes related to title generation, also update supstats2.
 	char title[128];
 	g_hCvarTitle.GetString(title, sizeof(title));
 	ReplaceString(title, sizeof(title), "{server}", g_sCachedHostname, false);

--- a/logstf/logstf.sp
+++ b/logstf/logstf.sp
@@ -125,7 +125,7 @@ Release notes:
 - Updated code to be compatible with SourceMod 1.12
 
 
----- 2.6.7 (22/07/2025) ----
+---- 2.7.0 (22/07/2025) ----
 - Changed match title trimming logic
 
 
@@ -150,7 +150,7 @@ TODO:
 #undef REQUIRE_PLUGIN
 #include <updater>
 
-#define PLUGIN_VERSION	"2.6.7"
+#define PLUGIN_VERSION	"2.7.0"
 #define UPDATE_URL		"https://sourcemod.krus.dk/logstf/update.txt"
 
 #define LOG_PATH  "logstf.log"

--- a/logstf/update.txt
+++ b/logstf/update.txt
@@ -4,10 +4,10 @@
 	{
 		"Version"
 		{
-			"Latest"	"2.6.7"
+			"Latest"	"2.7.0"
 		}
 		
-		"Notes"	"Changes in 2.6.7:"
+		"Notes"	"Changes in 2.7.0:"
 		"Notes"	"- Changed match title trimming logic"
 	}
 	

--- a/logstf/update.txt
+++ b/logstf/update.txt
@@ -4,11 +4,11 @@
 	{
 		"Version"
 		{
-			"Latest"	"2.6.6"
+			"Latest"	"2.6.7"
 		}
 		
-		"Notes"	"Changes in 2.6.6:"
-		"Notes"	"- Updated code to be compatible with SourceMod 1.12"
+		"Notes"	"Changes in 2.6.7:"
+		"Notes"	"- Changed match title trimming logic"
 	}
 	
 	"Files"

--- a/supstats2/README.md
+++ b/supstats2/README.md
@@ -15,7 +15,9 @@ Features:
 - Logs players spawning
 - Logs game pauses
 - Logs shots fired and shots hit (for certain weapons)
+- Logs unique match id, map name and title at the start of the match
 
-| CVAR                       | Default | Description          |
-| -------------------------- | ------- | -------------------- |
-| `supstats_accuracy <0\|1>` | `1`     | Enable accuracy logs |
+| CVAR                       | Default                    | Description                                                                                                                                                         |
+| -------------------------- | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `supstats_accuracy <0\|1>` | `1`                        | Enable accuracy logs                                                                                                                                                |
+| `logstf_title <title>`     | `{server}: {blu} vs {red}` | Sets the title of the log, which is logged at the start of the match.<br>Use `{server}` to insert the server title.<br>Use `{blu}` or `{red}` to insert team names. |

--- a/supstats2/supstats2.sp
+++ b/supstats2/supstats2.sp
@@ -385,12 +385,6 @@ public Action CheckPause(Handle timer, int client) {
 }
 
 void StartMatch() {
-	if (g_hTimerMatchStarted != null) {
-		delete g_hTimerMatchStarted;
-		g_hTimerMatchStarted = null;
-	}
-
-	g_hTimerMatchStarted = CreateTimer(10.0, MatchFullyStarted);
 }
 
 void ResetMatch() {
@@ -407,7 +401,17 @@ void EndMatch(bool endedMidgame) {
 	}
 }
 
-void MatchFullyStarted(Handle timer) {
+public void StartFirstRound() {
+	if (g_hTimerMatchStarted != null) {
+		delete g_hTimerMatchStarted;
+		g_hTimerMatchStarted = null;
+	}
+
+	// First log all the players spawning etc., and then we log the meta data.
+	g_hTimerMatchStarted = CreateTimer(0.5, LogMetaData);
+}
+
+void LogMetaData(Handle timer) {
 	g_hTimerMatchStarted = null;
 
     LogMatchId();

--- a/supstats2/supstats2.sp
+++ b/supstats2/supstats2.sp
@@ -241,7 +241,7 @@ public void OnPluginStart() {
 	g_hCvarEnableAccuracy.GetString(cvarEnableAccuracy, sizeof(cvarEnableAccuracy));
 	CvarChange_EnableAccuracy(g_hCvarEnableAccuracy, cvarEnableAccuracy, cvarEnableAccuracy);
 
-	// The "logstf_" prefix is because we are reusing the cvar from the logstf plugin.
+	// The "logstf_" prefix is used because we are reusing the cvar from the logstf plugin.
 	// This is done to avoid having all servers defining the title format twice.
 	g_hCvarLogsTitle = CreateConVar("logstf_title", "{server}: {blu} vs {red}", "Title for the log", FCVAR_NONE);
 	g_hCvarHostname = FindConVar("hostname");
@@ -387,6 +387,16 @@ public Action CheckPause(Handle timer, int client) {
 void StartMatch() {
 }
 
+public void StartFirstRound() {
+	if (g_hTimerMatchStarted != null) {
+		delete g_hTimerMatchStarted;
+		g_hTimerMatchStarted = null;
+	}
+
+	// First log all the players spawning etc., and then we log the meta data.
+	g_hTimerMatchStarted = CreateTimer(0.5, LogMetaData);
+}
+
 void ResetMatch() {
 	if (g_hTimerMatchStarted != null) {
 		delete g_hTimerMatchStarted;
@@ -399,16 +409,6 @@ void EndMatch(bool endedMidgame) {
 		delete g_hTimerMatchStarted;
 		g_hTimerMatchStarted = null;
 	}
-}
-
-public void StartFirstRound() {
-	if (g_hTimerMatchStarted != null) {
-		delete g_hTimerMatchStarted;
-		g_hTimerMatchStarted = null;
-	}
-
-	// First log all the players spawning etc., and then we log the meta data.
-	g_hTimerMatchStarted = CreateTimer(0.5, LogMetaData);
 }
 
 void LogMetaData(Handle timer) {

--- a/supstats2/update.txt
+++ b/supstats2/update.txt
@@ -8,7 +8,7 @@
 		}
 		
 		"Notes"	"Changes in 2.6.0:"
-		"Notes"	"- Log meta data at the start of the match (matchid, map)"
+		"Notes"	"- Log meta data at the start of the match (matchid, map, title)"
 	}
 	
 	"Files"

--- a/supstats2/update.txt
+++ b/supstats2/update.txt
@@ -4,11 +4,11 @@
 	{
 		"Version"
 		{
-			"Latest"	"2.5.4"
+			"Latest"	"2.6.0"
 		}
 		
-		"Notes"	"Changes in 2.5.4:"
-		"Notes"	"- Updated code to be compatible with SourceMod 1.12"
+		"Notes"	"Changes in 2.6.0:"
+		"Notes"	"- Log meta data at the start of the match (matchid, map)"
 	}
 	
 	"Files"


### PR DESCRIPTION
I want to log information that is not directly related to any in-game events.

Suggestion is in the PR.