### PR TITLE
Fixed mid-round upload causing server hitch visible to STV spectators

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Setup SourcePawn Compiler
-        uses: rumblefrog/setup-sp@v1.2.4
+        uses: rumblefrog/setup-sp@v1.3.1
         with:
           version: "1.12.x"
 
@@ -27,7 +27,7 @@ jobs:
         run: |
           pwsh prepare-publish.ps1
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           # Artifact name
           name: ftp-files
@@ -40,20 +40,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download files
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           # Artifact name
           name: ftp-files
           # Destination path
           path: ftp/
       - name: Set up node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v6
         with:
-          node-version: 16
+          node-version: 24
       - name: Install npm packages
         run: npm install fs path
       - name: Create release
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: Setup SourcePawn Compiler
         uses: rumblefrog/setup-sp@v1.3.1
         with:

--- a/logstf/logstf.sp
+++ b/logstf/logstf.sp
@@ -701,7 +701,37 @@ void UploadLog(bool partial) {
 	g_bIsUploading = true;
 	g_bIsPartialUpload = partial;
 
-	// Note: If you are making changes related to title generation, also update supstats2.
+	char path[64];
+	GetLogPath(LOG_PATH, path, sizeof(path));
+
+	if (partial) {
+		char partialpath[64];
+		GetLogPath(PLOG_PATH, partialpath, sizeof(partialpath));
+		DeleteFile(partialpath);
+		AnyHttp_CopyFile(path, partialpath, UploadLog_CopyComplete);
+	} else {
+		MC_PrintToChatAll("%s", "{lightgreen}[LogsTF] {blue}Uploading logs...");
+		UploadLog_Send(path);
+	}
+}
+
+void UploadLog_CopyComplete(bool success, any metadata) {
+	if (!success) {
+		LogError("Failed to create partial log file");
+		g_bIsUploading = false;
+		if (g_bReuploadASAP) {
+			g_bReuploadASAP = false;
+			UploadLog(false);
+		}
+		return;
+	}
+
+	char partialpath[64];
+	GetLogPath(PLOG_PATH, partialpath, sizeof(partialpath));
+	UploadLog_Send(partialpath);
+}
+
+void UploadLog_Send(const char[] logpath) {
 	char title[128];
 	g_hCvarTitle.GetString(title, sizeof(title));
 	ReplaceString(title, sizeof(title), "{server}", g_sCachedHostname, false);
@@ -709,39 +739,12 @@ void UploadLog(bool partial) {
 	ReplaceString(title, sizeof(title), "{blue}", g_sCachedBluTeamName, false);
 	ReplaceString(title, sizeof(title), "{red}", g_sCachedRedTeamName, false);
 
-	char path[64], partialpath[64];
-	GetLogPath(LOG_PATH, path, sizeof(path));
-	GetLogPath(PLOG_PATH, partialpath, sizeof(partialpath));
-
-	if (partial) {
-		DeleteFile(partialpath);
-		if (!CopyFile(path, partialpath)) {
-			LogError("Failed to create partial log file");
-			g_bIsUploading = false;
-			if (g_bReuploadASAP) {
-				g_bReuploadASAP = false;
-				UploadLog(false);
-			}
-			return;
-		}
-
-		// We should NOT add a Round_Stalemate just after a round has ended (logs.tf will not understand it)
-		//char buffer[128];
-		//char time[32];
-		//FormatTime(time, sizeof(time), "%m/%d/%Y - %H:%M:%S");
-		//FormatEx(buffer, sizeof(buffer), "\nL %s: %s\n", time, "World triggered \"Round_Stalemate\"");
-
-		//Handle file = OpenFile(partialpath, "a");
-		//WriteFileString(file, buffer, false);
-		//delete file;
-	}
-
-	if (!partial)
-		MC_PrintToChatAll("%s", "{lightgreen}[LogsTF] {blue}Uploading logs...");
+	char apiKey[64];
+	g_hCvarApikey.GetString(apiKey, sizeof(apiKey));
 
 	AnyHttpRequest req = AnyHttp.CreatePost("http://logs.tf/upload");
 
-	req.PutFile("logfile", partial ? partialpath : path);
+	req.PutFile("logfile", logpath);
 	req.PutString("title", title);
 	req.PutString("map", g_sCachedMap);
 	req.PutString("key", apiKey);

--- a/logstf/logstf.sp
+++ b/logstf/logstf.sp
@@ -133,6 +133,10 @@ Release notes:
 - Fixed unnecessary tournament restart when server is almost empty
 
 
+---- 2.8.0 (23/05/2026) ----
+- Reduced lag during mid-round log upload - by Arie
+
+
 TODO:
 - Some people run multiple instances of the same server (located in the same directory). This is a problem, because they all write to the same logstf.log file. Make the logstf.log and -partial files have dynamic names, and don't forget to clean them up.
 - Sanitize names for < and >, since logs.tf doesn't like those
@@ -154,7 +158,7 @@ TODO:
 #undef REQUIRE_PLUGIN
 #include <updater>
 
-#define PLUGIN_VERSION	"2.7.1"
+#define PLUGIN_VERSION	"2.8.0"
 #define UPDATE_URL		"https://sourcemod.krus.dk/logstf/update.txt"
 
 #define LOG_PATH  "logstf.log"

--- a/logstf/update.txt
+++ b/logstf/update.txt
@@ -4,11 +4,11 @@
 	{
 		"Version"
 		{
-			"Latest"	"2.7.1"
+			"Latest"	"2.8.0"
 		}
 		
-		"Notes"	"Changes in 2.7.1:"
-		"Notes"	"- Fixed unnecessary tournament restart when server is almost empty"
+		"Notes"	"Changes in 2.8.0:"
+		"Notes"	"- Reduced lag during mid-round log upload - by Arie"
 	}
 	
 	"Files"


### PR DESCRIPTION
Trying not to be "sloppy" here. Benchmarked the current code and this alternative to the mid-game log uploads that could cause end-of-round-lag to STV spectators. Benchmarked with realistic log sizes on the serveme docker image, showing the hitch with mid-game uploads, and the hitch being gone with this change:

The synchronous `CopyFile` during mid-game log uploads blocks the main thread for 60-100ms on typical log sizes, suspected to cause a visible hitch for STV spectators that spoils round endings.

Replaced with `AnyHttp_CopyFile`, which was already built for exactly this purpose, it spreads the file copy across multiple server frames. The log is still copied to a snapshot before uploading, so behavior is identical.

Only affects `logstf_midgameupload 1` (the default). End-of-match uploads were already async.

## Benchmark (native x86_64, 66.7 tick / 15ms budget)
Results of 3 benchmark runs on NVMe-based 14600k server.
| Log size | Before | After |
|----------|--------|-------|
| 100KB | 10-14 ms | 0.0 ms |
| 630KB | 64-73 ms | 0.0 ms |
| 1MB | 101-111 ms | 0.0 ms |